### PR TITLE
fix: handle conditions space problem

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,7 +18,7 @@ const regexes = [
   /\\mathb(it|f){([^{}]+)}([\^_])/g, // Match word-specific tags that are followed by math operators.
   /([\^_])\\mathb(it|f){([^{}]+)}/g, // Match word-specific tags with preceded by math operators.
 ];
-const replaceStrs = [" $2 ", "$2$3", "$1$3"];
+const replaceStrs = [" $2 ", " $2$3", "$1$3 "];
 
 /* Helper functions */
 

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,3 +3,5 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/extend-expect';
+


### PR DESCRIPTION
This PR makes sure that there is a space between conditions (i.e., `\ge`, `\le` ect.).