### PR TITLE
ci: renovate disable patch updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:base"],
-  "labels": ["bump:patch"]
+  "labels": ["bump:patch"],
+  "patch": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
This commit makes sure that renovate does not create a pull request for patch versions.